### PR TITLE
front: melhorando estrutura e visual para algo mais limpo ao usuario

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,17 +2,17 @@ name: CI
 
 on:
   push:
-    branches: [ main, master ]
+    branches: [main, master]
   pull_request:
-    branches: [ "**" ]
+    branches: ["**"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:
-  NODE_VERSION: '20'
-  PNPM_VERSION: '8'
+  NODE_VERSION: "20"
+  PNPM_VERSION: "8"
 
 jobs:
   lint:
@@ -231,12 +231,18 @@ jobs:
 
   secrets_scan:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Gitleaks
         uses: gitleaks/gitleaks-action@v2
-        with:
-          args: detect --redact --no-banner
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_VERSION: 8.24.3
 
   build:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ dist/
 build/
 .vercel/
 .cache/
+
+# Build
+apps/web/.next/

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,0 +1,68 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  :root {
+    --background: 0 0% 100%;
+    --foreground: 0 0% 3.9%;
+    --card: 0 0% 100%;
+    --card-foreground: 0 0% 3.9%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 0 0% 3.9%;
+    --primary: 0 0% 9%;
+    --primary-foreground: 0 0% 98%;
+    --secondary: 0 0% 96.1%;
+    --secondary-foreground: 0 0% 9%;
+    --muted: 0 0% 96.1%;
+    --muted-foreground: 0 0% 45.1%;
+    --accent: 0 0% 96.1%;
+    --accent-foreground: 0 0% 9%;
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 0 0% 98%;
+    --border: 0 0% 89.8%;
+    --input: 0 0% 89.8%;
+    --ring: 0 0% 3.9%;
+    --chart-1: 12 76% 61%;
+    --chart-2: 173 58% 39%;
+    --chart-3: 197 37% 24%;
+    --chart-4: 43 74% 66%;
+    --chart-5: 27 87% 67%;
+    --radius: 0.5rem
+  }
+  .dark {
+    --background: 0 0% 3.9%;
+    --foreground: 0 0% 98%;
+    --card: 0 0% 3.9%;
+    --card-foreground: 0 0% 98%;
+    --popover: 0 0% 3.9%;
+    --popover-foreground: 0 0% 98%;
+    --primary: 0 0% 98%;
+    --primary-foreground: 0 0% 9%;
+    --secondary: 0 0% 14.9%;
+    --secondary-foreground: 0 0% 98%;
+    --muted: 0 0% 14.9%;
+    --muted-foreground: 0 0% 63.9%;
+    --accent: 0 0% 14.9%;
+    --accent-foreground: 0 0% 98%;
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 0 0% 98%;
+    --border: 0 0% 14.9%;
+    --input: 0 0% 14.9%;
+    --ring: 0 0% 83.1%;
+    --chart-1: 220 70% 50%;
+    --chart-2: 160 60% 45%;
+    --chart-3: 30 80% 55%;
+    --chart-4: 280 65% 60%;
+    --chart-5: 340 75% 55%
+  }
+}
+
+@layer base {
+  * {
+    @apply border-border;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,30 +1,16 @@
-import type { ReactNode } from 'react';
-import Link from 'next/link';
-
+import { AppThemeProvider } from "@/components/theme-provider";
+import type { RootLayoutProps } from "../types";
 export const metadata = {
-  title: 'AliasMap',
-  description: 'OSINT username mapping with ethical, public-only collection.'
+  title: "AliasMap",
+  description: "OSINT username mapping with ethical, public-only collection.",
 };
 
-export default function RootLayout({ children }: { children: ReactNode }) {
+export default function RootLayout({ children }: RootLayoutProps) {
   return (
     <html lang="pt-BR">
-      <body style={{ fontFamily: 'system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Helvetica, Arial' }}>
-        <header style={{ padding: '12px 16px', borderBottom: '1px solid #e5e7eb' }}>
-          <nav style={{ display: 'flex', gap: 16, alignItems: 'center' }}>
-            <Link href="/">AliasMap</Link>
-            <Link href="/ethics">Aviso e Uso Ético</Link>
-          </nav>
-        </header>
-        <main style={{ maxWidth: 880, margin: '0 auto', padding: 16 }}>{children}</main>
-        <footer style={{ padding: 16, borderTop: '1px solid #e5e7eb', marginTop: 24 }}>
-          <small>
-            © {new Date().getFullYear()} AliasMap — Coleta apenas de dados públicos. Consulte{' '}
-            <Link href="/ethics">Aviso e Uso Ético</Link>.
-          </small>
-        </footer>
+      <body>
+        <AppThemeProvider>{children}</AppThemeProvider>
       </body>
     </html>
   );
 }
-

--- a/apps/web/components/CustomLoading.tsx
+++ b/apps/web/components/CustomLoading.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import * as React from "react";
+import Box from "@mui/material/Box";
+import { useTheme, alpha, lighten, darken } from "@mui/material/styles";
+import { keyframes } from "@mui/system";
+import type { CustomLoadingProps } from "../types";
+
+const barAnim = keyframes`
+  0% { background-position: left; }
+  100% { background-position: right; }
+`;
+const searchAnim = keyframes`
+  0% { transform: translateX(0%) rotate(70deg); }
+  100% { transform: translateX(100px) rotate(10deg); }
+`;
+
+export default function CustomLoadingScreen({ width = 130, barHeight = 8, ariaLabel = "Carregando" }: CustomLoadingProps) {
+  const theme = useTheme();
+  const primary = theme.palette.primary.main;
+  const primaryLight = theme.palette.primary.light ?? lighten(primary, 0.35);
+  const primaryDark = theme.palette.primary.dark ?? darken(primary, 0.3);
+  const primarySoft = alpha(primary, 0.22);
+
+  return (
+    <Box
+      component="output"
+      aria-live="polite"
+      aria-label={ariaLabel}
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        width: "100%",
+        minHeight: `calc(${barHeight}px * 10)`,
+      }}
+    >
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          position: "relative",
+          width,
+          height: "fit-content",
+        }}
+      >
+        <Box
+          sx={{
+            width: "100%",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "flex-start",
+            justifyContent: "center",
+            gap: "10px",
+          }}
+        >
+          <Box
+            component="span"
+            sx={{
+              width: "100%",
+              height: barHeight,
+              borderRadius: "10px",
+              background: `linear-gradient(to right, ${primaryDark}, ${primaryLight}, ${primaryDark})`,
+              backgroundSize: "200% 100%",
+              animation: `${barAnim} 3s ease-in-out infinite alternate-reverse`,
+              "@media (prefers-reduced-motion: reduce)": {
+                animation: "none !important",
+              },
+            }}
+          />
+          <Box
+            component="span"
+            sx={{
+              width: "50%",
+              height: barHeight,
+              borderRadius: "10px",
+              background: `linear-gradient(to right, ${primaryDark}, ${primaryLight}, ${primaryDark})`,
+              backgroundSize: "200% 100%",
+              animation: `${barAnim} 3s ease-in-out infinite alternate-reverse`,
+              "@media (prefers-reduced-motion: reduce)": {
+                animation: "none !important",
+              },
+            }}
+          />
+        </Box>
+        <Box
+          component="svg"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 101 114"
+          aria-hidden="true"
+          sx={{
+            position: "absolute",
+            left: "-25px",
+            mt: "18px",
+            zIndex: 2,
+            width: "70%",
+            color: primaryDark,
+            animation: `${searchAnim} 3s ease-in-out infinite alternate-reverse`,
+            "@media (prefers-reduced-motion: reduce)": {
+              animation: "none !important",
+            },
+            "& circle, & line": {
+              stroke: "currentColor",
+            },
+            "& circle": {
+              fill: primarySoft,
+            },
+          }}
+        >
+          <circle cx="46.1726" cy="46.1727" r="29.5497" transform="rotate(36.0692 46.1726 46.1727)" strokeWidth={7} />
+          <line x1="61.7089" y1="67.7837" x2="97.7088" y2="111.784" strokeWidth={7} />
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/apps/web/components/EthicsPage.tsx
+++ b/apps/web/components/EthicsPage.tsx
@@ -1,0 +1,55 @@
+import { Container, Paper, Typography, Box, Alert, useTheme } from "@mui/material";
+import { AlertTriangle, Info, CheckCircle } from "lucide-react";
+import { disclaimerPt } from "../lib/constants";
+
+export const metadata = { title: "Aviso e Uso Ético — AliasMap" };
+
+export default function EthicsPage() {
+  const theme = useTheme();
+  return (
+    <Container>
+      <Alert severity="warning" icon={<AlertTriangle size={20} />} sx={{ borderRadius: 2, background: "transparent" }}>
+        <Typography variant="body2" fontWeight="medium">
+          Leia atentamente todos os termos antes de utilizar nossos serviços
+        </Typography>
+      </Alert>
+      <Paper
+        elevation={1}
+        sx={{
+          p: 3,
+          backgroundColor: "transparent",
+          borderRadius: 2,
+          border: "none",
+        }}
+      >
+        <Box sx={{ display: "flex", alignItems: "center", mb: 2 }}>
+          <Info size={20} color={theme.palette.text.primary} style={{ marginRight: "8px" }} />
+          <Typography variant="h6" color={theme.palette.text.primary} fontWeight="medium">
+            Aviso e Uso Ético
+          </Typography>
+        </Box>
+        <Typography
+          component="div"
+          variant="body1"
+          sx={{
+            whiteSpace: "pre-wrap",
+            lineHeight: 1.7,
+            color: "text.primary",
+            fontSize: "0.95rem",
+            fontFamily: '"Roboto", "Helvetica", "Arial", sans-serif',
+          }}
+        >
+          {disclaimerPt}
+        </Typography>
+      </Paper>
+      <Box sx={{ mt: 4, textAlign: "center" }}>
+        <Box sx={{ display: "flex", justifyContent: "center", mb: 2 }}>
+          <CheckCircle size={24} color="#4caf50" style={{ marginRight: "8px" }} />
+          <Typography variant="body2" color="success.main" fontWeight="medium">
+            Ao utilizar nossos serviços, você concorda com estes termos
+          </Typography>
+        </Box>
+      </Box>
+    </Container>
+  );
+}

--- a/apps/web/components/LoadingScreen.tsx
+++ b/apps/web/components/LoadingScreen.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import * as React from "react";
+import { Stack, Typography, LinearProgress, Alert } from "@mui/material";
+import CustomLoadingScreen from "./CustomLoading";
+import type { LoadingProps } from "../types";
+
+export default function LoadingScreen({ progress, error }: LoadingProps) {
+  return (
+    <Stack spacing={2} alignItems="center" justifyContent="center" sx={{ textAlign: "center" }}>
+      <Typography variant="h6">Varredura em andamento</Typography>
+
+      <LinearProgress
+        variant="determinate"
+        value={progress.total ? (progress.done / progress.total) * 100 : 0}
+        color={error ? "error" : "info"}
+        sx={{ width: "60%" }}
+      />
+
+      <CustomLoadingScreen width={150} barHeight={10} ariaLabel="Varredura em andamento" />
+
+      {!!error && <Alert severity="warning">{error}</Alert>}
+    </Stack>
+  );
+}

--- a/apps/web/components/ResultsScreen.tsx
+++ b/apps/web/components/ResultsScreen.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import * as React from "react";
+import { Stack, Typography, Alert } from "@mui/material";
+import { MindmapPreview } from "@/components/MindmapPreview";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
+import type { ResultsScreenProps } from "../types";
+
+export default function ResultsScreen({ hasData, trimmed, foundOnly, events }: ResultsScreenProps) {
+  return (
+    <Stack spacing={2}>
+      <Typography variant="h6">Resultado</Typography>
+      {!hasData ? (
+        <Alert severity="info" icon={<InfoOutlinedIcon />}>
+          Nenhuma evidência confirmada.
+        </Alert>
+      ) : (
+        <MindmapPreview username={trimmed} items={foundOnly} events={events} />
+      )}
+    </Stack>
+  );
+}

--- a/apps/web/components/SearchScreen.tsx
+++ b/apps/web/components/SearchScreen.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import * as React from "react";
+import { Stack, TextField, Button } from "@mui/material";
+import PlayArrowIcon from "@mui/icons-material/PlayArrow";
+import type { SearchScreenProps } from "../types";
+
+export default function SearchScreen({ onStart, loading = false }: SearchScreenProps) {
+  const [username, setUsername] = React.useState("");
+  const trimmed = username.trim();
+  const isValid = trimmed.length >= 3 && /^[a-zA-Z0-9._-]{3,32}$/.test(trimmed);
+
+  return (
+    <Stack
+      direction={{ xs: "column", sm: "row" }}
+      spacing={1.5}
+      alignItems={{ xs: "stretch", sm: "center" }}
+      sx={{ border: "none", boxShadow: "none" }}
+    >
+      <TextField
+        fullWidth
+        placeholder="Digite um username"
+        size="small"
+        value={username}
+        onChange={(e) => setUsername(e.target.value)}
+        disabled={loading}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && isValid) onStart(trimmed);
+        }}
+        inputProps={{ "aria-label": "username" }}
+      />
+
+      <Stack direction="row" spacing={1} flexShrink={0} justifyContent="flex-end">
+        <Button
+          variant="contained"
+          startIcon={<PlayArrowIcon />}
+          onClick={() => onStart(trimmed)}
+          disabled={!isValid || loading}
+          aria-disabled={!isValid || loading}
+        >
+          Iniciar
+        </Button>
+      </Stack>
+    </Stack>
+  );
+}

--- a/apps/web/components/theme-provider.tsx
+++ b/apps/web/components/theme-provider.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import * as React from "react";
+import { createTheme, ThemeProvider, CssBaseline } from "@mui/material";
+import type { NodeProps } from "../types";
+
+const LIGHT = {
+  primary: { main: "#0B1B34", light: "#4A90E2", dark: "#003B5C" },
+  secondary: { main: "#16C5C0" },
+  background: { default: "#f0f0f0", paper: "#FFFFFF" },
+  text: { primary: "#0B1B34", secondary: "#374151" },
+  error: { main: "#EF4444" },
+  found: "#10B981",
+  inconclusive: "#F59E0B",
+  not_found: "#6B7280",
+  unknown: "#EF4444",
+} as const;
+
+const DARK = {
+  primary: { main: "#0D2D3A", light: "#4A90E2", dark: "#003B5C" },
+  secondary: { main: "#F9FAFB" },
+  background: { default: "#0B1B34", paper: "#111827" },
+  text: { primary: "#FFFFFF", secondary: "#9CA3AF" },
+  error: { main: "#EF4444" },
+  found: "#10B981",
+  inconclusive: "#F59E0B",
+  not_found: "#9CA3AF",
+  unknown: "#EF4444",
+} as const;
+
+export function AppThemeProvider({ children }: NodeProps) {
+  const [mode, setMode] = React.useState<"light" | "dark">("dark");
+  React.useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    const apply = (e: MediaQueryListEvent | MediaQueryList) => {
+      const isDark = "matches" in e ? e.matches : mq.matches;
+      setMode(isDark ? "dark" : "light");
+    };
+    apply(mq);
+    mq.addEventListener("change", apply);
+    return () => {
+      mq.removeEventListener("change", apply);
+    };
+  }, []);
+
+  const theme = React.useMemo(
+    () =>
+      createTheme({
+        palette: {
+          mode,
+          ...(mode === "light" ? (LIGHT as any) : (DARK as any)),
+        },
+        typography: {
+          fontFamily: "system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Helvetica, Arial",
+        },
+      }),
+    [mode]
+  );
+
+  return (
+    <ThemeProvider theme={theme}>
+      <CssBaseline enableColorScheme />
+      {children}
+    </ThemeProvider>
+  );
+}

--- a/apps/web/lib/constants.ts
+++ b/apps/web/lib/constants.ts
@@ -1,6 +1,4 @@
-export const disclaimerPt = `# Aviso e Uso Ético
-
-Este projeto (AliasMap) é não-oficial e não afiliado ao Sherlock Project. Destina-se a fins educacionais e investigações legítimas/autorizadas. Ao continuar, você declara que entende e concorda com os termos abaixo:
+export const disclaimerPt = `Este projeto (AliasMap) é não-oficial e não afiliado ao Sherlock Project. Destina-se a fins educacionais e investigações legítimas/autorizadas. Ao continuar, você declara que entende e concorda com os termos abaixo:
 
 - Coletamos somente informações publicamente acessíveis. Não realizamos login, não contornamos controles e não interagimos com fluxos de recuperação além da página inicial (apenas 1 tentativa e parsing estático).
 - Não persistimos dados no servidor. Resultados são exibidos apenas na sua sessão; export é local e sob sua responsabilidade.

--- a/apps/web/lib/utils.ts
+++ b/apps/web/lib/utils.ts
@@ -1,0 +1,4 @@
+// Se usar shadcn: ajuste para o seu caminho util de "cn"
+export function cn(...classes: (string | undefined | false)[]) {
+  return classes.filter(Boolean).join(" ");
+}

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -3,4 +3,3 @@
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.
-

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,14 @@
     "e2e": "echo 'e2e offline placeholder' && exit 0"
   },
   "dependencies": {
+    "@emotion/react": "^11.14.0",
+    "@emotion/styled": "^11.14.1",
+    "@mui/icons-material": "^5.18.0",
+    "@mui/material": "^5.18.0",
+    "@mui/system": "^5.18.0",
+    "@mui/utils": "^5.17.1",
+    "@tailwindcss/postcss": "^4.1.13",
+    "lucide-react": "^0.542.0",
     "next": "14.2.5",
     "react": "18.3.1",
     "react-dom": "18.3.1"
@@ -22,10 +30,13 @@
     "@types/node": "20.12.12",
     "@types/react": "18.2.66",
     "@types/react-dom": "18.2.22",
+    "@vitest/coverage-v8": "1.6.0",
+    "autoprefixer": "^10.4.19",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
     "eslint": "8.57.0",
     "eslint-config-next": "14.2.5",
     "typescript": "5.5.3",
-    "vitest": "1.6.0",
-    "@vitest/coverage-v8": "1.6.0"
+    "vitest": "1.6.0"
   }
 }

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "lib": ["dom", "dom.iterable", "es2020"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "es2020"
+    ],
     "allowJs": false,
     "skipLibCheck": true,
     "strict": true,
@@ -13,9 +17,25 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "types": ["node"]
+    "types": [
+      "node"
+    ],
+    "paths": {
+      "@/*": ["./*"]
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }
-

--- a/apps/web/types/index.ts
+++ b/apps/web/types/index.ts
@@ -1,0 +1,79 @@
+import type { ReactNode } from "react";
+
+export type NodeProps = Readonly<{ children: ReactNode }>;
+
+export type RootLayoutProps = Readonly<{
+  children: ReactNode;
+}>;
+
+export type CustomLoadingProps = Readonly<{
+  width?: number;
+  barHeight?: number;
+  ariaLabel?: string;
+}>;
+
+export type LoadingProps = Readonly<{
+  progress: { done: number; total: number };
+  error?: string;
+}>;
+
+export type LegendProps = Readonly<{ label: string; color: string }>;
+
+export type EdgeProps = Readonly<{
+  idx: number;
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+  animate?: boolean;
+  prefix: string;
+}>;
+
+export type Status = "found" | "not_found" | "inconclusive";
+
+export type MindmapItem = Readonly<{
+  platform: string;
+  status: Status;
+  rawStatus?: Status;
+  heuristic?: boolean;
+  url?: string;
+}>;
+
+export type MindmapPreviewProps = Readonly<{
+  username: string;
+  items: MindmapItem[];
+  width?: number;
+  height?: number;
+  radius?: number;
+  className?: string;
+  maxLabel?: number;
+  events: SiteEvent[];
+  exportData?: boolean;
+}>;
+
+export type SiteEvent =
+  | { type: "site_start"; id: string }
+  | {
+      type: "site_result";
+      id: string;
+      status: string;
+      url?: string;
+      latencyMs?: number;
+      reason?: string;
+      heuristic?: boolean;
+    }
+  | { type: "site_error"; id: string; reason: string }
+  | { type: "progress"; done: number; total: number }
+  | { type: "done"; summary: { done: number; total: number } };
+
+export type ResultsScreenProps = Readonly<{
+  events: SiteEvent[];
+  hasData: boolean;
+  trimmed: string;
+  foundOnly: MindmapItem[];
+}>;
+
+export type SearchScreenProps = Readonly<{
+  onStart: (username: string) => void;
+  loading?: boolean;
+}>;


### PR DESCRIPTION
## Descrição
- [x] Explique claramente o objetivo da mudança e o impacto no usuário.

Alterada estrutura de front para um ux mais amigável e direta ao usuario, adicionado suporte ao thema dark e light para uso com base no sistema, adicionada tela de loading, centralizado em arquivos de types a tipagem do sistema para não ter duplicidade.

## Escopo da Mudança
- [ ] Código da API/Engine
- [x] UI/UX (inclua screenshots/gifs)
- [ ] Manifesto de sites (`docs/sites.core.yaml`)
- [ ] Documentação (`docs/*`)

## Checklist de Qualidade (Architect)
- [x] Lint e typecheck passam (`pnpm lint`, `pnpm typecheck`)
- [x] Testes unit/contract/e2e passam e cobertura mantida (≥ 85% no core)
- [x] Contrato SSE estável (`site_start`, `site_result`, `progress`, `done`)

## Segurança (Agent Smith / Neo / Trinity)
- [x] Entrada validada (regex/allowlist por site), sem SSRF
- [x] Sem persistência de dados; logs sem PII
- [x] Semgrep e audit sem achados alto/crit
- [x] Nenhum segredo no código (Gitleaks)
- [x] Threat model revisado se superfícies mudaram

## Notas de Implementação
- [ ] Para telas de recuperação: 1 tentativa, sem seguir links, apenas parsing da página inicial
- [ ] Identificadores mascarados rotulados corretamente

## Outras Observações
Sugiro a adição de uma lib de tradução para poder melhorar a UX do usuario adicionando linguagem EN-US.

## Theme

### DARK
<img width="1871" height="912" alt="Captura de tela 2025-09-09 083542" src="https://github.com/user-attachments/assets/41045e45-609c-450e-b310-0698e6f55533" />
<img width="1870" height="911" alt="Captura de tela 2025-09-09 083549" src="https://github.com/user-attachments/assets/1700e896-4d7b-4ce0-ad56-05b4499d7b2c" />
<img width="1860" height="908" alt="Captura de tela 2025-09-09 083600" src="https://github.com/user-attachments/assets/7365ad7c-ce67-4c22-b2f5-e8dc6716484f" />
<img width="1862" height="907" alt="Captura de tela 2025-09-09 083640" src="https://github.com/user-attachments/assets/716725a7-35f2-4db9-85b8-1d44f7f2499d" />

### LIGHT

<img width="1871" height="916" alt="Captura de tela 2025-09-09 090602" src="https://github.com/user-attachments/assets/8a112c6b-39c5-4902-8b5c-3fcf21386a4e" />
<img width="1874" height="916" alt="Captura de tela 2025-09-09 090607" src="https://github.com/user-attachments/assets/97f6af38-dfb7-44be-8256-010c53417c24" />
<img width="1864" height="911" alt="Captura de tela 2025-09-09 090616" src="https://github.com/user-attachments/assets/9c77da19-9e1b-4ea8-86ec-80555966056d" />
<img width="1870" height="919" alt="Captura de tela 2025-09-09 090638" src="https://github.com/user-attachments/assets/8b7212a0-74ce-495d-a84f-4770fdf90472" />

