### PR TITLE
css: ajustando cores do projeto para se adequar ao site yeslinux

### DIFF
--- a/apps/web/components/LoadingScreen.tsx
+++ b/apps/web/components/LoadingScreen.tsx
@@ -13,7 +13,7 @@ export default function LoadingScreen({ progress, error }: LoadingProps) {
       <LinearProgress
         variant="determinate"
         value={progress.total ? (progress.done / progress.total) * 100 : 0}
-        color={error ? "error" : "info"}
+        color={error ? "error" : "secondary"}
         sx={{ width: "60%" }}
       />
 

--- a/apps/web/components/theme-provider.tsx
+++ b/apps/web/components/theme-provider.tsx
@@ -5,7 +5,11 @@ import { createTheme, ThemeProvider, CssBaseline } from "@mui/material";
 import type { NodeProps } from "../types";
 
 const LIGHT = {
-  primary: { main: "#0B1B34", light: "#4A90E2", dark: "#003B5C" },
+  primary: { 
+    main: "#00ff41", 
+    light: "#41d165ff",
+    dark: "#006118ff"
+  },
   secondary: { main: "#16C5C0" },
   background: { default: "#f0f0f0", paper: "#FFFFFF" },
   text: { primary: "#0B1B34", secondary: "#374151" },
@@ -16,10 +20,15 @@ const LIGHT = {
   unknown: "#EF4444",
 } as const;
 
+
 const DARK = {
-  primary: { main: "#0D2D3A", light: "#4A90E2", dark: "#003B5C" },
+  primary: {
+    main: "#00ff41",
+    light: "#41d165ff",
+    dark: "#006118ff",
+  },
   secondary: { main: "#F9FAFB" },
-  background: { default: "#0B1B34", paper: "#111827" },
+  background: { default: "#010409e6", paper: "#010409e6" },
   text: { primary: "#FFFFFF", secondary: "#9CA3AF" },
   error: { main: "#EF4444" },
   found: "#10B981",


### PR DESCRIPTION
## Descrição
- [x] Explique claramente o objetivo da mudança e o impacto no usuário.

ajustando cores do projeto para se adequar ao site yeslinux

## Escopo da Mudança
- [ ] Código da API/Engine
- [x] UI/UX (inclua screenshots/gifs)
- [ ] Manifesto de sites (`docs/sites.core.yaml`)
- [ ] Documentação (`docs/*`)

## Checklist de Qualidade (Architect)
- [x] Lint e typecheck passam (`pnpm lint`, `pnpm typecheck`)
- [x] Testes unit/contract/e2e passam e cobertura mantida (≥ 85% no core)
- [x] Contrato SSE estável (`site_start`, `site_result`, `progress`, `done`)

## Segurança (Agent Smith / Neo / Trinity)
- [x] Entrada validada (regex/allowlist por site), sem SSRF
- [x] Sem persistência de dados; logs sem PII
- [x] Semgrep e audit sem achados alto/crit
- [x] Nenhum segredo no código (Gitleaks)
- [x] Threat model revisado se superfícies mudaram

## Notas de Implementação
- [ ] Para telas de recuperação: 1 tentativa, sem seguir links, apenas parsing da página inicial
- [ ] Identificadores mascarados rotulados corretamente

## Outras Observações
- Issues relacionadas: #
- Screenshots/Anexos:
- 
<img width="1858" height="909" alt="Captura de tela 2025-09-09 110601" src="https://github.com/user-attachments/assets/307dc238-96b2-4c0d-80f0-4c38cf5481bc" />
<img width="1847" height="908" alt="Captura de tela 2025-09-09 110638" src="https://github.com/user-attachments/assets/6ba0437b-e8cb-4fef-b764-2af99d9eb4a7" />
<img width="1849" height="907" alt="Captura de tela 2025-09-09 110812" src="https://github.com/user-attachments/assets/a3fe762c-38c3-464e-9141-c80df4c65090" />
<img width="1862" height="919" alt="Captura de tela 2025-09-09 110648" src="https://github.com/user-attachments/assets/a65342a8-bccd-42be-97c2-894211be06ef" />
