### PR TITLE
change: css para cor bg preta, ajustado para na tela de loading não p…

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -146,7 +146,7 @@ export default function HomeStepsSimple() {
               AliasMap
             </Typography>
 
-            {step > 0 && (
+            {step > 0 && step != 1 && (
               <Tooltip title="Reiniciar">
                 <IconButton onClick={resetAll}>
                   <RestartAltIcon />

--- a/apps/web/components/theme-provider.tsx
+++ b/apps/web/components/theme-provider.tsx
@@ -28,7 +28,7 @@ const DARK = {
     dark: "#006118ff",
   },
   secondary: { main: "#F9FAFB" },
-  background: { default: "#010409e6", paper: "#010409e6" },
+  background: { default: "#000", paper: "#000" },
   text: { primary: "#FFFFFF", secondary: "#9CA3AF" },
   error: { main: "#EF4444" },
   found: "#10B981",


### PR DESCRIPTION
…arecer o reinicio

## Descrição
- [X ] Explique claramente o objetivo da mudança e o impacto no usuário.

- CSS: Cor BG #000
- Loading: removido reset na tela de loading

## Escopo da Mudança
- [ ] Código da API/Engine
- [X ] UI/UX (inclua screenshots/gifs)
- [ ] Manifesto de sites (`docs/sites.core.yaml`)
- [ ] Documentação (`docs/*`)

## Checklist de Qualidade (Architect)
- [X ] Lint e typecheck passam (`pnpm lint`, `pnpm typecheck`)
- [X ] Testes unit/contract/e2e passam e cobertura mantida (≥ 85% no core)
- [X ] Contrato SSE estável (`site_start`, `site_result`, `progress`, `done`)

## Segurança (Agent Smith / Neo / Trinity)
- [ X] Entrada validada (regex/allowlist por site), sem SSRF
- [ X] Sem persistência de dados; logs sem PII
- [X ] Semgrep e audit sem achados alto/crit
- [X ] Nenhum segredo no código (Gitleaks)
- [X ] Threat model revisado se superfícies mudaram

## Notas de Implementação
- [ ] Para telas de recuperação: 1 tentativa, sem seguir links, apenas parsing da página inicial
- [ ] Identificadores mascarados rotulados corretamente

## Outras Observações
- Issues relacionadas: #
- Screenshots/Anexos:

<img width="376" height="823" alt="image" src="https://github.com/user-attachments/assets/ead8c6b4-26fb-4129-b27d-c238e743ded6" />
