### PR TITLE
frame: add profile url to iframe config

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,25 +1,34 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
+const ALLOWED_ORIGIN = 'https://fonteeboa.netlify.app';
+
 export function middleware(req: NextRequest) {
   const res = NextResponse.next();
+
+  res.headers.set('Access-Control-Allow-Origin', ALLOWED_ORIGIN);
+  res.headers.set('Access-Control-Allow-Credentials', 'true');
+  res.headers.set('Access-Control-Allow-Methods', 'GET,POST,PUT,DELETE,OPTIONS');
+  res.headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization');
   res.headers.set('Referrer-Policy', 'no-referrer');
   res.headers.set('X-Content-Type-Options', 'nosniff');
-  res.headers.set('X-Frame-Options', 'DENY');
-  // Relaxed CSP to allow Next inline bootstrap scripts so hydration works.
-  // If we want strict nonce-based CSP later, we can wire Next's nonce helpers.
+  res.headers.set('X-Frame-Options', 'SAMEORIGIN');
+
   const csp = [
     "default-src 'self'",
-    "img-src 'self' https: data:",
+    "img-src 'self' data:",
     "style-src 'self' 'unsafe-inline'",
     "script-src 'self' 'unsafe-inline'",
     "connect-src 'self'",
-    "font-src 'self' data:"
+    "font-src 'self'",
+    `frame-ancestors 'self' ${ALLOWED_ORIGIN}`,
   ].join('; ');
+
   res.headers.set('Content-Security-Policy', csp);
+
   return res;
 }
 
 export const config = {
-  matcher: ['/((?!_next/static|_next/image|favicon.ico).*)']
+  matcher: ['/((?!_next/static|_next/image|favicon.ico).*)'],
 };


### PR DESCRIPTION
## Descrição
- [x ] Explique claramente o objetivo da mudança e o impacto no usuário.

Adicionando permissão de iframe de siteportifolio para constar no ifram utilizado pelos meus projetos.

## Escopo da Mudança
- [ ] Código da API/Engine
- [ ] UI/UX (inclua screenshots/gifs)
- [ ] Manifesto de sites (`docs/sites.core.yaml`)
- [ ] Documentação (`docs/*`)
- [X] Validações

## Checklist de Qualidade (Architect)
- [x] Lint e typecheck passam (`pnpm lint`, `pnpm typecheck`)
- [x] Testes unit/contract/e2e passam e cobertura mantida (≥ 85% no core)
- [x] Contrato SSE estável (`site_start`, `site_result`, `progress`, `done`)

## Segurança (Agent Smith / Neo / Trinity)
- [x] Entrada validada (regex/allowlist por site), sem SSRF
- [x] Sem persistência de dados; logs sem PII
- [x] Semgrep e audit sem achados alto/crit
- [x] Nenhum segredo no código (Gitleaks)
- [x] Threat model revisado se superfícies mudaram

## Notas de Implementação
- [ ] Para telas de recuperação: 1 tentativa, sem seguir links, apenas parsing da página inicial
- [ ] Identificadores mascarados rotulados corretamente

## Outras Observações
- Issues relacionadas: #
- Screenshots/Anexos:
